### PR TITLE
Sync with original attributes

### DIFF
--- a/src/VirtualColumn.php
+++ b/src/VirtualColumn.php
@@ -30,6 +30,7 @@ trait VirtualColumn
 
         foreach ($model->getAttribute(static::getDataColumn()) ?? [] as $key => $value) {
             $model->setAttribute($key, $value);
+            $model->syncOriginalAttribute($key);
         }
 
         $model->setAttribute(static::getDataColumn(), null);
@@ -52,6 +53,7 @@ trait VirtualColumn
                 ]));
 
                 unset($model->attributes[$key]);
+                unset($model->original[$key]);
             }
         }
 

--- a/tests/VirtualColumnTest.php
+++ b/tests/VirtualColumnTest.php
@@ -44,7 +44,7 @@ class VirtualColumnTest extends TestCase
         ]);
 
         $this->assertSame('baz', $model->foo);
-        $this->assertSame('bar', $model->getOriginal('foo'));
+        $this->assertSame('baz', $model->getOriginal('foo'));
         $this->assertSame('xyz', $model->abc);
         $this->assertSame('xyz', $model->getOriginal('abc'));
         $this->assertSame(null, $model->data);

--- a/tests/VirtualColumnTest.php
+++ b/tests/VirtualColumnTest.php
@@ -34,6 +34,7 @@ class VirtualColumnTest extends TestCase
         // Model has the correct structure when retrieved
         $model = MyModel::first();
         $this->assertSame('bar', $model->foo);
+        $this->assertSame('bar', $model->getOriginal('foo'));
         $this->assertSame(null, $model->data);
 
         // Model can be updated
@@ -43,7 +44,9 @@ class VirtualColumnTest extends TestCase
         ]);
 
         $this->assertSame('baz', $model->foo);
+        $this->assertSame('bar', $model->getOriginal('foo'));
         $this->assertSame('xyz', $model->abc);
+        $this->assertSame('xyz', $model->getOriginal('abc'));
         $this->assertSame(null, $model->data);
 
         // Model can be retrieved after update & is structure correctly


### PR DESCRIPTION
When retrieving, virtual columns are added to the `attributes` array. This PR sync the value so it also shows the value in the `original` attribute array. 
When saving/updating/creating, the value is also unset from the original attribute array.

This allows the developer to use `isDirty()` or `getDirty()` if needed.