### PR TITLE
Add getCustomColumns function

### DIFF
--- a/src/VirtualColumn.php
+++ b/src/VirtualColumn.php
@@ -45,7 +45,10 @@ trait VirtualColumn
         }
 
         foreach ($model->getAttributes() as $key => $value) {
-            if (! in_array($key, static::getCustomColumns())) {
+
+            if ((static::getVirtualColumns() && in_array($key, static::getVirtualColumns(), true))
+                || ! in_array($key, static::getCustomColumns())
+            ) {
                 $current = $model->getAttribute(static::getDataColumn()) ?? [];
 
                 $model->setAttribute(static::getDataColumn(), array_merge($current, [
@@ -131,6 +134,13 @@ trait VirtualColumn
     public static function getDataColumn(): string
     {
         return 'data';
+    }
+
+    public static function getVirtualColumns(): array
+    {
+        return [
+            //
+        ];
     }
 
     public static function getCustomColumns(): array

--- a/tests/etc/migrations/2022_10_24_000001_create_virtual_models_table.php
+++ b/tests/etc/migrations/2022_10_24_000001_create_virtual_models_table.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class CreateVirtualModelsTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('virtual_models', function (Blueprint $table) {
+            $table->increments('id');
+
+            $table->json('data');
+        });
+    }
+
+    public function down()
+    {
+        Schema::dropIfExists('foo_models');
+    }
+}


### PR DESCRIPTION
Hello @stancl,

This PR adds the function `getVirtualColumns`, which allows you to define which attributs you want to set as virtual columns instead of defining your custom columns. There are two main reasons why this is useful:

1) Many times I've had issues because someone in our team would add a new column but not add it in the `getCustomColumns` which would mess things up.

2) We always have many more custom columns than virtual columns. So we sometimes end up with an array with 30 attributes inside.

If `getVirtualColumns()` is defined, it will ignore `getCustomColumns`. Which is like how `protected $fillable = [];`and `protected $guarded = [];`