### PR TITLE
Allow to use guardable functions

### DIFF
--- a/src/VirtualColumn.php
+++ b/src/VirtualColumn.php
@@ -155,4 +155,15 @@ trait VirtualColumn
 
         return static::getDataColumn() . '->' . $column;
     }
+
+    /**
+     * Determine if the given column is a valid, guardable column.
+     *
+     * @param  string  $key
+     * @return bool
+     */
+    protected function isGuardableColumn($key)
+    {
+        return true;
+    }
 }


### PR DESCRIPTION
This pull request allows you to continue using the guarded function of eloquent.
Now to use virtualcolumn I always have to set `$guarded = [];`
With this change, however, you can continue to use the protection function as you always have.
We can find the default function in `vendor/laravel/framework/src/Illuminate/Database/Eloquent/Concerns/GuardsAttributes.php`
```php
    /**
     * Determine if the given column is a valid, guardable column.
     *
     * @param  string  $key
     * @return bool
     */
    protected function isGuardableColumn($key)
    {
        if (! isset(static::$guardableColumns[get_class($this)])) {
            $columns = $this->getConnection()
                        ->getSchemaBuilder()
                        ->getColumnListing($this->getTable());

            if (empty($columns)) {
                return true;
            }
            static::$guardableColumns[get_class($this)] = $columns;
        }

        return in_array($key, static::$guardableColumns[get_class($this)]);
    }
```
i changed it a bit to allow all columns to be guarded
```php
    /**
     * Determine if the given column is a valid, guardable column.
     *
     * @param  string  $key
     * @return bool
     */
    protected function isGuardableColumn($key)
    {
        return true;
    }
```