### PR TITLE
Test that child models extending a parent that uses VirtualColumn get encoded correctly

### DIFF
--- a/tests/VirtualColumnTest.php
+++ b/tests/VirtualColumnTest.php
@@ -106,10 +106,8 @@ class VirtualColumnTest extends TestCase
     }
 
     /** @test */
-    public function models_extending_a_parent_using_virtualcolumn_get_encoded_incorrectly()
+    public function models_extending_a_parent_model_using_virtualcolumn_get_encoded_correctly()
     {
-        // todo1 Fix this unintended behavior
-
         // Create a model that extends a parent model using VirtualColumn
         // 'foo' is a custom column, 'data' is the virtual column
         FooChild::create(['foo' => 'foo']);
@@ -118,35 +116,13 @@ class VirtualColumnTest extends TestCase
         $this->assertNull($encodedFoo->data);
         $this->assertSame($encodedFoo->foo, 'foo');
 
-        // Creating another child model of the same parent doesn't encode the attributes correctly
+        // Create another child model of the same parent
         // 'bar' is a custom column, 'data' is the virtual column
         BarChild::create(['bar' => 'bar']);
         $encodedBar = DB::select('select * from bar_childs limit 1')[0];
 
-        /*
-         * Each child model gets encoded using the first child model's encoding listener.
-         * The encodeAttributes event listeners get registered for each child model
-         * in $afterListeners – a static property, so the state is shared between all child models.
-         *
-         * The runAfterListeners method runs all listeners for the registered event,
-         * including the listener for encoding the first child model before attempting to encode the second child.
-         *
-         * However, after encoding the second child model's attributes using the first listener,
-         * $dataEncodingStatus changes to 'encoded', meaning the next listener (the one intended for the second child)
-         * won't encode the attributes.
-         *
-         * That results in the second child model being encoded using the first child model's custom columns,
-         * and the second child model's custom columns won't be recognized as "real"/custom columns.
-         *
-         * The intended behavior would be
-         * $this->assertNull($encodedBar->data);
-         * $this->assertSame($encodedBar->bar, 'bar');
-         */
-
-        // Assert that the second child model was encoded incorrectly
-        $this->assertNotNull($encodedBar->data);
-        $this->assertNull($encodedBar->bar);
-        $this->assertSame($encodedBar->data, json_encode(['bar' => 'bar']));
+        $this->assertNull($encodedBar->data);
+        $this->assertSame($encodedBar->bar, 'bar');
     }
 
     // maybe add an explicit test that the saving() and updating() listeners don't run twice?

--- a/tests/VirtualColumnTest.php
+++ b/tests/VirtualColumnTest.php
@@ -2,7 +2,6 @@
 
 namespace Stancl\VirtualColumn\Tests;
 
-use Exception;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Facades\DB;
 use Orchestra\Testbench\TestCase;

--- a/tests/etc/migrations/2023_05_11_000001_create_bar_childs_table.php
+++ b/tests/etc/migrations/2023_05_11_000001_create_bar_childs_table.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class CreateBarChildsTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('bar_childs', function (Blueprint $table) {
+            $table->increments('id');
+
+            $table->string('bar')->nullable();
+
+            $table->json('data')->nullable();
+        });
+    }
+
+    public function down()
+    {
+        Schema::dropIfExists('bar_childs');
+    }
+}

--- a/tests/etc/migrations/2023_05_11_000001_create_bar_models_table.php
+++ b/tests/etc/migrations/2023_05_11_000001_create_bar_models_table.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class CreateBarModelsTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('bar_models', function (Blueprint $table) {
+            $table->increments('id');
+
+            $table->string('custom1');
+
+            $table->json('data')->nullable();
+        });
+    }
+
+    public function down()
+    {
+        Schema::dropIfExists('bar_models');
+    }
+}

--- a/tests/etc/migrations/2023_10_21_000001_create_foo_childs_table.php
+++ b/tests/etc/migrations/2023_10_21_000001_create_foo_childs_table.php
@@ -6,7 +6,7 @@ use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 
-class CreateBarModelsTable extends Migration
+class CreateFooChildsTable extends Migration
 {
     /**
      * Run the migrations.
@@ -15,10 +15,10 @@ class CreateBarModelsTable extends Migration
      */
     public function up()
     {
-        Schema::create('bar_models', function (Blueprint $table) {
+        Schema::create('foo_childs', function (Blueprint $table) {
             $table->increments('id');
 
-            $table->string('custom1');
+            $table->string('foo')->nullable();
 
             $table->json('data')->nullable();
         });
@@ -26,6 +26,6 @@ class CreateBarModelsTable extends Migration
 
     public function down()
     {
-        Schema::dropIfExists('bar_models');
+        Schema::dropIfExists('foo_childs');
     }
 }


### PR DESCRIPTION
Add a failing test that checks if multiple child models can extend a parent model that uses VirtualColumn without encoding issues. Fixed in #14 