### PR TITLE
Handle encrypted columns which are set to null

### DIFF
--- a/src/VirtualColumn.php
+++ b/src/VirtualColumn.php
@@ -45,7 +45,7 @@ trait VirtualColumn
         foreach ($this->getAttribute(static::getDataColumn()) ?? [] as $key => $value) {
             $attributeHasEncryptedCastable = in_array(data_get($this->getCasts(), $key), $encryptedCastables);
 
-            if ($attributeHasEncryptedCastable && $this->valueEncrypted($value)) {
+            if ($value && $attributeHasEncryptedCastable && $this->valueEncrypted($value)) {
                 $this->attributes[$key] = $value;
             } else {
                 $this->setAttribute($key, $value);

--- a/tests/VirtualColumnTest.php
+++ b/tests/VirtualColumnTest.php
@@ -143,13 +143,16 @@ class VirtualColumnTest extends TestCase
             'json' => json_encode(['foo', 'bar']), // 'encrypted:json'
             'object' => (object) json_encode(['foo', 'bar']), // 'encrypted:object'
             'custom' => 'foo', // Custom castable – 'EncryptedCast::class'
+            'null_value' => null, // 'encrypted'
         ]);
 
         foreach($encryptedAttributes as $key => $expectedValue) {
             $savedValue = $model->getAttributes()[$key]; // Encrypted
 
-            $this->assertTrue($model->valueEncrypted($savedValue));
-            $this->assertNotEquals($expectedValue, $savedValue);
+            if ($savedValue !== null) {
+                $this->assertTrue($model->valueEncrypted($savedValue));
+                $this->assertNotEquals($expectedValue, $savedValue);
+            }
 
             $retrievedValue = $model->$key; // Decrypted
 
@@ -178,6 +181,7 @@ class MyModel extends ParentModel
         'json' => 'encrypted:json',
         'object' => 'encrypted:object',
         'custom' => EncryptedCast::class,
+        'null_value' => 'encrypted',
     ];
 }
 


### PR DESCRIPTION
The PR solves an issue whereby if an encrypted virtual column is set to `null` a TypeError is thrown when accessing it:

```
local.ERROR: Stancl\Tenancy\Database\Models\Tenant::valueEncrypted(): Argument #1 ($value) must be of type string, null given, called in /var/www/html/vendor/stancl/virtualcolumn/src/VirtualColumn.php on line 48
```