### PR TITLE
Include timestamps in `getCustomColumns()` by default, fix tests (use new #[Test] attribute)

### DIFF
--- a/src/VirtualColumn.php
+++ b/src/VirtualColumn.php
@@ -182,6 +182,8 @@ trait VirtualColumn
     {
         return [
             'id',
+            static::CREATED_AT,
+            static::UPDATED_AT,
         ];
     }
 

--- a/tests/VirtualColumnTest.php
+++ b/tests/VirtualColumnTest.php
@@ -163,6 +163,29 @@ class VirtualColumnTest extends TestCase
         // Reset static property
         MyModel::$customEncryptedCastables = [];
     }
+
+    #[Test]
+    public function updating_model_does_not_store_timestamps_in_the_virtual_column() {
+        /** @var TimestampModel $model */
+        $model = TimestampModel::create();
+        $dbRecordDataColumn = fn () => DB::selectOne('select * from timestamp_models where id = ?', [$model->id])->data;
+
+        $this->assertStringNotContainsString('created_at', $dbRecordDataColumn());
+        $this->assertStringNotContainsString('updated_at', $dbRecordDataColumn());
+
+        $model->update(['data' => ['virtual' => 'bar']]);
+
+        $this->assertStringNotContainsString('created_at', $dbRecordDataColumn());
+        $this->assertStringNotContainsString('updated_at', $dbRecordDataColumn());
+    }
+}
+
+class TimestampModel extends Model
+{
+    use VirtualColumn;
+
+    public $timestamps = true;
+    protected $guarded = [];
 }
 
 class ParentModel extends Model

--- a/tests/VirtualColumnTest.php
+++ b/tests/VirtualColumnTest.php
@@ -8,6 +8,7 @@ use Illuminate\Support\Facades\Crypt;
 use Illuminate\Database\Eloquent\Model;
 use Stancl\VirtualColumn\VirtualColumn;
 use Illuminate\Contracts\Database\Eloquent\CastsAttributes;
+use PHPUnit\Framework\Attributes\Test;
 
 class VirtualColumnTest extends TestCase
 {
@@ -18,7 +19,7 @@ class VirtualColumnTest extends TestCase
         $this->loadMigrationsFrom(__DIR__ . '/etc/migrations');
     }
 
-    /** @test */
+    #[Test]
     public function keys_which_dont_have_their_own_column_go_into_data_json_column()
     {
         $model = MyModel::create([
@@ -59,7 +60,7 @@ class VirtualColumnTest extends TestCase
         $this->assertSame(null, $model->data);
     }
 
-    /** @test */
+    #[Test]
     public function model_is_always_decoded_when_accessed_by_user_event()
     {
         MyModel::retrieved(function (MyModel $model) {
@@ -90,7 +91,7 @@ class VirtualColumnTest extends TestCase
         MyModel::first();
     }
 
-    /** @test */
+    #[Test]
     public function column_names_are_generated_correctly()
     {
         // FooModel's virtual data column name is 'virtual'
@@ -107,7 +108,7 @@ class VirtualColumnTest extends TestCase
         $this->assertSame($virtualColumnName, $model->getColumnForQuery('foo'));
     }
 
-    /** @test */
+    #[Test]
     public function models_extending_a_parent_model_using_virtualcolumn_get_encoded_correctly()
     {
         // Create a model that extends a parent model using VirtualColumn
@@ -130,7 +131,7 @@ class VirtualColumnTest extends TestCase
 
     // maybe add an explicit test that the saving() and updating() listeners don't run twice?
 
-    /** @test */
+    #[Test]
     public function encrypted_casts_work_with_virtual_column() {
         // Custom encrypted castables have to be specified in the $customEncryptedCastables static property
         MyModel::$customEncryptedCastables = [EncryptedCast::class];

--- a/tests/etc/migrations/2020_05_11_000001_create_timestamp_models_table.php
+++ b/tests/etc/migrations/2020_05_11_000001_create_timestamp_models_table.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class CreateTimestampModelsTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('timestamp_models', function (Blueprint $table) {
+            $table->increments('id');
+
+            $table->timestamps();
+            $table->json('data');
+        });
+    }
+
+    public function down()
+    {
+        Schema::dropIfExists('timestamp_models');
+    }
+}


### PR DESCRIPTION
### Stop timestamps from getting saved in virtual column
Model timestamps have custom columns. When a model with timestamps _gets updated_, the timestamps get saved in the virtual column, unless they're specified in `getCustomColumns()`. This PR adds the default timestamp columns to the default `getCustomColumns()` method.

### Fix tests
In some PHPUnit version (likely 10.x, not properly documented though), the `/** @test */` annotations no longer work for marking functions in test files as tests. Instead, the function names either have to start with `test` (e.g. `public function testThatSomethingWorks`), or have the `#[Test]` attribute.

This PR deletes the `/** @test */` annotations from the tests and makes the tests use the `#[Test]` attribute instead.